### PR TITLE
[BUGFIX] Fix date errorcheck

### DIFF
--- a/Classes/Validator/ErrorCheck/Date.php
+++ b/Classes/Validator/ErrorCheck/Date.php
@@ -35,8 +35,18 @@ class Date extends AbstractErrorCheck
 
         if (isset($this->gp[$this->formFieldName]) && strlen(trim($this->gp[$this->formFieldName])) > 0) {
             $pattern = $this->utilityFuncs->getSingle($this->settings['params'], 'pattern');
-            if (\DateTime::createFromFormat($pattern, $this->gp[$this->formFieldName]) === FALSE) {
+            try {
+                \DateTime::createFromFormat($pattern, $this->gp[$this->formFieldName]);
+                $status = \DateTime::getLastErrors();
+                if((isset($status['warning_count']) && intval($status['warning_count']) > 0) ||
+                    (isset($status['error_count']) && intval($status['error_count']) > 0)) {
+
+                    $checkFailed = $this->getCheckFailed();
+                    $this->utilityFuncs->debugMessage('Result:', array(), 2, $status);
+                }
+            } catch(\Exception $e) {
                 $checkFailed = $this->getCheckFailed();
+                $this->utilityFuncs->debugMessage($e->getMessage());
             }
         }
         return $checkFailed;


### PR DESCRIPTION
`createFromFormat()` doesn't always return false in
case of an error. It must be retrieved manually later.

Resolves: #73452 (https://forge.typo3.org/issues/73452)