### PR TITLE
Marker ABS_URL generates borken action URLs

### DIFF
--- a/Classes/View/Form.php
+++ b/Classes/View/Form.php
@@ -426,7 +426,7 @@ class Form extends AbstractView
             $markers['###TIMESTAMP###'] = htmlspecialchars($this->gp['formtime']);
         }
         $markers['###RANDOM_ID###'] = htmlspecialchars($this->gp['randomID']);
-        $markers['###ABS_URL###'] = \TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl('') . $path;
+        $markers['###ABS_URL###'] = \TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl($path);
         $markers['###rel_url###'] = $markers['###REL_URL###'];
         $markers['###timestamp###'] = $markers['###TIMESTAMP###'];
         $markers['###abs_url###'] = $markers['###ABS_URL###'];


### PR DESCRIPTION
Marker ###ABS_URL### generates broken action URLs.

Scenario: 
Host: _http://typo3.local/_
AbsPrefix: _/test/_
Domain: _http://typo3.local/test_

Genrated URL:
`http://typo3.local/test//test/test-seiten/formhandler/`

Changing `Form.php#429` results in:

`http://typo3.local/test/test-seiten/formhandler/`



