### PR TITLE
[TASK] Split eiD endpoints from Classes containing logic to be able to overwrite and extend instead of only overwrite

### DIFF
--- a/Classes/Ajax/RemoveFile.php
+++ b/Classes/Ajax/RemoveFile.php
@@ -131,6 +131,3 @@ class RemoveFile
     }
 
 }
-
-$obj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\Typoheads\Formhandler\Ajax\RemoveFile::class);
-$obj->main();

--- a/Classes/Ajax/Submit.php
+++ b/Classes/Ajax/Submit.php
@@ -98,6 +98,3 @@ class Submit
     }
 
 }
-
-$obj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\Typoheads\Formhandler\Ajax\Submit::class);
-$obj->main();

--- a/Classes/Ajax/Validate.php
+++ b/Classes/Ajax/Validate.php
@@ -115,6 +115,3 @@ class Validate
     }
 
 }
-
-$obj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\Typoheads\Formhandler\Ajax\Validate::class);
-$obj->main();

--- a/Classes/Http/RemoveFile.php
+++ b/Classes/Http/RemoveFile.php
@@ -1,0 +1,5 @@
+<?php
+namespace Typoheads\Formhandler\Http;
+
+$obj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\Typoheads\Formhandler\Ajax\RemoveFile::class);
+$obj->main();

--- a/Classes/Http/Submit.php
+++ b/Classes/Http/Submit.php
@@ -1,0 +1,5 @@
+<?php
+namespace Typoheads\Formhandler\Http;
+
+$obj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\Typoheads\Formhandler\Ajax\Submit::class);
+$obj->main();

--- a/Classes/Http/Validate.php
+++ b/Classes/Http/Validate.php
@@ -1,0 +1,5 @@
+<?php
+namespace Typoheads\Formhandler\Http;
+
+$obj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\Typoheads\Formhandler\Ajax\Validate::class);
+$obj->main();

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -9,9 +9,9 @@ if (!defined('TYPO3_MODE')) {
 //Hook in tslib_content->stdWrap
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_content.php']['stdWrap'][$_EXTKEY] = 'Typoheads\Formhandler\Hooks\StdWrapHook';
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']['formhandler'] = 'EXT:formhandler/Classes/Ajax/Validate.php';
-$GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']['formhandler-removefile'] = 'EXT:formhandler/Classes/Ajax/RemoveFile.php';
-$GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']['formhandler-ajaxsubmit'] = 'EXT:formhandler/Classes/Ajax/Submit.php';
+$GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']['formhandler'] = 'EXT:formhandler/Classes/Http/Validate.php';
+$GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']['formhandler-removefile'] = 'EXT:formhandler/Classes/Http/RemoveFile.php';
+$GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']['formhandler-ajaxsubmit'] = 'EXT:formhandler/Classes/Http/Submit.php';
 
 // load default PageTS config from static file
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $_EXTKEY . '/Configuration/TypoScript/pageTsConfig.ts">');


### PR DESCRIPTION
Hi Reinhard, 

as we discussed, splitting the endPoint from the logic allow us to extend from the original provided Classes in our custom ones that overwrite the endPoint

Best,
Juan Manuel. 